### PR TITLE
Update MySqlStorage.cs

### DIFF
--- a/Hangfire.MySql/MySqlStorage.cs
+++ b/Hangfire.MySql/MySqlStorage.cs
@@ -39,11 +39,11 @@ namespace Hangfire.MySql.Core
                 {
                     if (connectionString.Last() != ';')
                     {
-                        connectionString += connectionString + ";IgnoreCommandTransaction=true;";
+                        connectionString += ";IgnoreCommandTransaction=true;";
                     }
                     else
                     {
-                        connectionString += connectionString + "IgnoreCommandTransaction=true;";
+                        connectionString += "IgnoreCommandTransaction=true;";
                     }
                 }
                 _connectionString = connectionString;


### PR DESCRIPTION
The Connectionstring was adding duplicate values.  as a result of which  the dictionary was not able to add duplicate key values  in  the below code snippet 

` _connectionString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
                    .Select(x => x.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries))
                    .Select(x => new { Key = x[0].Trim(), Value = x.Length>1? x[1].Trim():"" })
                    .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
`