### PR TITLE
Update MySqlDistributedLock.cs

### DIFF
--- a/Hangfire.MySql/MySqlDistributedLock.cs
+++ b/Hangfire.MySql/MySqlDistributedLock.cs
@@ -54,6 +54,7 @@ namespace Hangfire.MySql.Core
             return
                 _connection
                     .Execute(
+                        "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; " +
                         $"INSERT INTO {_options.TablePrefix}_DistributedLock (Resource, CreatedAt) " +
                         "  SELECT @resource, @now " +
                         "  FROM dual " +


### PR DESCRIPTION
AcquireLock偶尔会报死锁的错误
参考https://github.com/arnoldasgudas/Hangfire.MySqlStorage/blob/master/Hangfire.MySql/MySqlDistributedLock.cs
发现漏了一句