### PR TITLE
Allow providing existing connection to MysqlStorage

### DIFF
--- a/Hangfire.MySql/MySqlStorage.cs
+++ b/Hangfire.MySql/MySqlStorage.cs
@@ -78,10 +78,10 @@ namespace Hangfire.MySql.Core
             return connectionString + ";Allow User Variables=True;";
         }
 
-        internal MySqlStorage(MySqlConnection existingConnection)
+        public MySqlStorage(MySqlConnection existingConnection, MySqlStorageOptions options = null)
         {
 	        _existingConnection = existingConnection ?? throw new ArgumentNullException("existingConnection");
-            _options = new MySqlStorageOptions();
+            _options = options ?? new MySqlStorageOptions();
 
             InitializeQueueProviders();
         }


### PR DESCRIPTION
I quickly made this change through the Github editor. It would be great if we were allowed to pass an existing connection object into the MysqlStorage object.
My use case is that the storage is plugged into an existing system where connections are provided on demand.

Is there a specific reason you want a connection string explicitly?