### PR TITLE
Update Install.sql -> specify Score float precision

### DIFF
--- a/Hangfire.MySql/Install.sql
+++ b/Hangfire.MySql/Install.sql
@@ -120,7 +120,7 @@ CREATE TABLE `<tableprefix>_Set` (
   `Id` int(11) NOT NULL AUTO_INCREMENT,
   `Key` varchar(100) NOT NULL,
   `Value` varchar(256) NOT NULL,
-  `Score` float NOT NULL,
+  `Score` float(12, 0)) NOT NULL,
   `ExpireAt` datetime DEFAULT NULL,
   PRIMARY KEY (`Id`),
   UNIQUE KEY `IX_Set_Key_Value` (`Key`,`Value`)


### PR DESCRIPTION
Hi, pls refer to the commit log, column `Score` should specify the float precision.

Due to the `Score` is used to store timestamp of job and it is float without precision assignment, the timestamp will store wrong value.
It will cause job processing on the wrong time even on the before time.
Pls see the table result below:

**Without precision:**  

![image](https://user-images.githubusercontent.com/37995141/83590525-88f34100-a588-11ea-8246-85697d2706f5.png)

**With precision:**

![image](https://user-images.githubusercontent.com/37995141/83590501-7b3dbb80-a588-11ea-820d-58d8279655b2.png)
